### PR TITLE
Pylint sqlalchemy

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pylint
           pip install pylint_flask_sqlalchemy
           pip install -r requirements.txt
       - name: Analysing the code with pylint
         run: |
-          pylint `ls -R|grep .py$|xargs`
+          pylint --load-plugins pylint_flask_sqlalchemy `ls -R|grep .py$|xargs`

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint
+          pip install pylint_flask_sqlalchemy
           pip install -r requirements.txt
       - name: Analysing the code with pylint
         run: |


### PR DESCRIPTION
Plugin for pylint_flask_sqlalchemy needed to be loaded from pylint in the workflow.

Closes #37 